### PR TITLE
Use irm in the uv installation script

### DIFF
--- a/install_uv.bat
+++ b/install_uv.bat
@@ -1,7 +1,7 @@
 @echo off
 if not exist "%APPDATA%\Balatro\Mods\SlayTheJokers\uvx.exe" (
     set UV_UNMANAGED_INSTALL=%APPDATA%\Balatro\Mods\SlayTheJokers
-    powershell -ExecutionPolicy ByPass -Command "iex(New-Object Net.WebClient).DownloadString('https://astral.sh/uv/install.ps1')"
+    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 )
 %APPDATA%\Balatro\Mods\SlayTheJokers\uvx.exe --with psutil --with google-cloud-storage python@3.12 -c 'import psutil, google.cloud'
 echo All required Python libraries have been installed.


### PR DESCRIPTION
WebClient is outdated and isn't liked by modern antiviruses. The official uv repository also recommends using `irm`.